### PR TITLE
TestInactivity

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ matrix:
   include:
     - os: windows
       script:
-        - go test -v -race -tags unit -run "^Test.*InactivityTimeout$" -count 1000 -timeout 100m ./agent/dockerclient/dockerapi/
+        - go test -v -race -tags unit -run "^TestInactivity$" -count 4000 -timeout 100m ./agent/dockerclient/dockerapi/

--- a/agent/dockerclient/dockerapi/docker_client_test.go
+++ b/agent/dockerclient/dockerapi/docker_client_test.go
@@ -25,6 +25,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1084,6 +1085,49 @@ func TestStatsInactivityTimeout(t *testing.T) {
 	newStat := <-stats
 
 	assert.Nil(t, newStat)
+}
+
+func TestInactivity(t *testing.T) {
+	readerDelay := 300 * time.Millisecond
+	inactivityDelay := 100 * time.Millisecond
+
+	timeoutHappens, _ := testInactivity(readerDelay, inactivityDelay)
+
+	assert.True(t, <-timeoutHappens)
+}
+
+func testInactivity(readerDelay time.Duration, inactivityDelay time.Duration) (<-chan bool, error) {
+	timeoutHappens := make(chan bool)
+
+	// mimic stats reading goroutine
+	go func() {
+		// marker that indicates whether inactivity timeout is triggered
+		var canceled uint32
+
+		// mimic inactivity handling goroutine, execute all atomic load/add and sleep operations
+		go func(canceled *uint32) {
+			var callCount uint64
+			atomic.AddUint64(&callCount, 1)
+
+			// it takes two loops for the inactivity handler to detect inactivity
+			time.Sleep(inactivityDelay)
+			atomic.LoadUint64(&callCount)
+
+			time.Sleep(inactivityDelay)
+			atomic.LoadUint64(&callCount)
+
+			atomic.AddUint32(canceled, 1)
+		}(&canceled)
+
+		time.Sleep(readerDelay)
+		if atomic.LoadUint32(&canceled) != 0 { // inactivity timeout is triggered
+			timeoutHappens <- true
+		} else {
+			timeoutHappens <- false
+		}
+	}()
+
+	return timeoutHappens, nil
 }
 
 func TestStatsInactivityTimeoutNoHit(t *testing.T) {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [ ] Builds on Linux (`make release`)
- [ ] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [ ] Unit tests on Linux (`make test`) pass
- [ ] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
